### PR TITLE
fix: do not set FALLBACK

### DIFF
--- a/lua/filetype.lua
+++ b/lua/filetype.lua
@@ -131,8 +131,6 @@ function M.resolve()
     -- so let's just default to the extension name
     if extension then
         setf(extension)
-    else -- There is no extension
-        setf("FALLBACK")
     end
 end
 


### PR DESCRIPTION
This inteferes with the filetype set by plugins.

E.g: when using packer.nvim, after `:PackerSync` a display window is
opened and the plugin manually sets the filetype to `packer`.
`indent.nvim` was resetting it to [FALLBACK] wrongly.