### PR TITLE
Fix python3 shebang detection

### DIFF
--- a/lua/filetype/init.lua
+++ b/lua/filetype/init.lua
@@ -60,8 +60,8 @@ end
 local function analyze_shebang()
     local fstline = vim.api.nvim_buf_get_lines(0, 0, 1, true)[1]
     if fstline then
-        return fstline:match("#!%s*/usr/bin/env%s+(%a+)$")
-            or fstline:match("#!%s*/.*/(%a+)$")
+        return fstline:match("#!%s*/usr/bin/env%s+(%S+)$")
+            or fstline:match("#!%s*/%S+/([^ /]+)$")
     end
 end
 

--- a/lua/filetype/mappings.lua
+++ b/lua/filetype/mappings.lua
@@ -1555,6 +1555,7 @@ M.function_complex = {
 
 M.shebang = {
     ["bash"] = "sh",
+    ["python3"] = "python",
 }
 
 return M


### PR DESCRIPTION
* Match any non-space character after '/usr/bin/env', not just letters
* Add a shebang mapping from python3 to python
