### PR TITLE
feat: add shebang mapping for nodejs

### DIFF
--- a/lua/filetype/mappings/function.lua
+++ b/lua/filetype/mappings/function.lua
@@ -589,6 +589,7 @@ M.complex = {
 
 M.shebang = {
     ["bash"] = "sh",
+    ["node"] = "javascript",
 }
 
 return M


### PR DESCRIPTION
Following `filetype.vim` that set `ft=javscript` for nodejs shebang.