### PR TITLE
fix: filename match failed on windows system

### DIFF
--- a/lua/filetype/init.lua
+++ b/lua/filetype/init.lua
@@ -155,7 +155,7 @@ function M.resolve()
         return
     end
 
-    local filename = absolute_path:match(".*%/(.*)")
+    local filename = absolute_path:match(".*[\\/](.*)")
     local ext = filename:match(".*%.(%w+)")
 
     -- Try to match the custom defined filetypes


### PR DESCRIPTION
Windows system has a different path separator from linux, eg:

- Windows: C:\User\verf\Appdata\Local\nvim
- Linux: /home/verf/.config/nvim

Commit https://github.com/nathom/filetype.nvim/commit/26ef9b00f040b33ee7afdc768bcffdc9e3cf4b9c has modified the matching method of file suffixes, but only match the path separator of the Linux system. Causes the following problems on Windows system:
![1](https://user-images.githubusercontent.com/22053969/143370959-2efb17e3-39d7-454c-9b30-bef760bd105a.png)

This pr fixed this problem, allowing file name matching to support both Windows and Linux systems.
