### PR TITLE
Fix shebang error when custom_map is nil

### DIFF
--- a/lua/filetype/init.lua
+++ b/lua/filetype/init.lua
@@ -180,7 +180,7 @@ function M.resolve()
     -- This should be reworked to include well-known shebangs as node -> javascript
     local shebang = analyze_shebang()
     if shebang then
-        if custom_map.shebang then
+        if custom_map and custom_map.shebang then
             shebang = custom_map.shebang[shebang]
         end
         set_filetype(shebang)


### PR DESCRIPTION
`custom_map` can be nil here and throw an error.