### PR TITLE
Make function_complex work

### DIFF
--- a/lua/filetype/init.lua
+++ b/lua/filetype/init.lua
@@ -49,9 +49,8 @@ local function try_regex(absolute_path, maps, star_set)
                     return true
                 end
             else
-                if set_filetype(ft) then
-                    return true
-                end
+                set_filetype(ft)
+                return true
             end
         end
     end
@@ -127,6 +126,11 @@ function M.resolve()
         if try_regex(absolute_path, custom_map.complex) then
             return
         end
+
+        if try_regex(absolute_path, custom_map.function_complex) then
+            return
+        end
+
         if try_regex(absolute_path, custom_map.star_sets, true) then
             return
         end


### PR DESCRIPTION
`try_lookup` returns true when query is in map even if set_filetype
returns false.
For that reason, `function_literal` using `try_lookup` works.

On the other hand, `function_complex` using `try_regex` did not work
because `set_filetype` returns false and `try_regex` returns false.

This commit resolve the issue by make it always return true when regexp matches the absolute_path.
This behavior is consistent with `try_lookup`.

Conflicts #55 ~but #55 did not work for me~. Sorry #55 worked, but this is backward(explained in README.md) compatibility PR.