### PR TITLE
Fix shebang not working on dotfiles

### DIFF
--- a/lua/filetype/init.lua
+++ b/lua/filetype/init.lua
@@ -59,7 +59,7 @@ local function try_regex(absolute_path, maps, star_set)
 end
 
 local function try_lookup(query, map)
-    if map == nil then
+    if query == nil or map == nil then
         return false
     end
     if map[query] ~= nil then
@@ -109,7 +109,7 @@ function M.resolve()
     end
 
     local filename = absolute_path:match(".*[\\/](.*)")
-    local ext = filename:match(".*%.(%w+)")
+    local ext = filename:match(".+%.(%w+)")
 
     -- Try to match the custom defined filetypes
     if custom_map ~= nil then


### PR DESCRIPTION
Changed the extension regex to require characters before the dot and the
try_lookup function to not use a nil as a query.

For context I was trying to open a file named ".xinitrc", and filetype
was getting set to "xinitrc". I saw #37 and thought I just had to update,
but the issue was still there.