### PR TITLE
Set ruby filetype when extension is rake

### DIFF
--- a/lua/filetype/mappings/extensions.lua
+++ b/lua/filetype/mappings/extensions.lua
@@ -435,6 +435,7 @@ return {
     ["qc"] = "c",
     ["quake"] = "m3quake",
     ["rad"] = "radiance",
+    ["rake"] = "ruby",
     ["raku"] = "raku",
     ["rakudoc"] = "raku",
     ["rakumod"] = "raku",


### PR DESCRIPTION
Make sure that the filetype is `ruby` for files with the `rake` extension. This follows what [`filetype.vim` does](https://github.com/neovim/neovim/blob/3449405f38961ac297638ced6377d75cfcb610ca/runtime/filetype.vim#L1598).
