### PR TITLE
Fix Not an editor command: dist#ft#SetFileTypeSH("bash")

### DIFF
--- a/lua/filetype/mappings/function.lua
+++ b/lua/filetype/mappings/function.lua
@@ -553,16 +553,16 @@ M.complex = {
         vim.cmd([[dist#ft#SetFileTypeSH("bash")]])
     end,
     ["%.bash[_-]profile"] = function()
-        vim.cmd([[dist#ft#SetFileTypeSH("bash")]])
+        vim.cmd([[call dist#ft#SetFileTypeSH("bash")]])
     end,
     ["%.bash[_-]logout"] = function()
-        vim.cmd([[dist#ft#SetFileTypeSH("bash")]])
+        vim.cmd([[call dist#ft#SetFileTypeSH("bash")]])
     end,
     ["%.bash[_-]aliases"] = function()
-        vim.cmd([[dist#ft#SetFileTypeSH("bash")]])
+        vim.cmd([[call dist#ft#SetFileTypeSH("bash")]])
     end,
-    ["%.bash-fc[_-]"] = function()
-        vim.cmd([[dist#ft#SetFileTypeSH("bash")]])
+    ["%.bash%-fc[_-]"] = function()
+        vim.cmd([[call dist#ft#SetFileTypeSH("bash")]])
     end,
     ["PKGBUILD.*"] = function()
         vim.cmd([[dist#ft#SetFileTypeSH("bash")]])
@@ -590,7 +590,7 @@ M.complex = {
 M.shebang = {
     ["bash"] = "sh",
     ["node"] = "javascript",
-    ['python3'] = 'python'
+    ["python3"] = "python",
 }
 
 return M


### PR DESCRIPTION
I found that adding `call` command fixes the #68 issue.

However, I don't really understand why `call` commands are used for codes before line 532 and codes after line 532 don't have `call` commands.

Only `%.bash[_-]profile`, `%.bash[_-]logout`, `%.bash[_-]aliases`, `%.bash%-fc[_-]` need to have `call` commands added , while the rest works without any issues.

I also found that the plugin does not detect `.bash-fc_`. Escaping the dash `-` inside `%.bash-fc[_-]` string seems fixes the issue.