### PR TITLE
fix: `analyze_shebang` not detecting flags

### DIFF
--- a/lua/filetype/init.lua
+++ b/lua/filetype/init.lua
@@ -73,8 +73,8 @@ end
 local function analyze_shebang()
     local fstline = vim.api.nvim_buf_get_lines(0, 0, 1, true)[1]
     if fstline then
-        return fstline:match("#!%s*/usr/bin/env%s+(%S+)$")
-            or fstline:match("#!%s*/%S+/([^ /]+)$")
+        return fstline:match("#!%s*/usr/bin/env%s+(%S+)")
+            or fstline:match("#!%s*/%S+/([^ /]+)")
     end
 
     return false


### PR DESCRIPTION
The pattern matching doesn't account for flags given to the shebang.
Remove the '$' line end match to be less restrictive.

```lua
-- TEST
local function analyze_shebang(fstline)
  if fstline then
    return fstline:match("#!%s*/usr/bin/env%s+(%S+)") or
             fstline:match("#!%s*/%S+/([^ /]+)")
  end

  return false
end

print(analyze_shebang("#!/usr/bin/make -f"))
print(analyze_shebang("#!/usr/bin/make"))
print(analyze_shebang("#!/usr/bin/env make"))
print(analyze_shebang("#!/usr/bin/env make -f"))
```
```
make
make
make
make
```